### PR TITLE
some changes needed by eCairn to integrate DataSift library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dependencies
 
 If you're using the source you'll need to install the dependencies.
 
-sudo gem install yajl-ruby json rest-client
+sudo gem install yajl-ruby rest-client
 
 Simple example
 --------------

--- a/datasift.gemspec
+++ b/datasift.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 	s.required_rubygems_version	= Gem::Requirement.new(">= 1.3.6") if s.respond_to? :required_rubygems_version=
 
 	s.add_runtime_dependency('rest-client', '~> 1.6.3')
-	s.add_runtime_dependency('json', '~> 1')
 	s.add_runtime_dependency('yajl-ruby', '~> 0.8.2')
 	s.add_development_dependency('rdoc', '~> 0')
 	s.add_development_dependency('shoulda', '~> 2.11.3')

--- a/lib/DataSift/apiclient.rb
+++ b/lib/DataSift/apiclient.rb
@@ -9,7 +9,7 @@
 # DataSift API.
 
 require 'rest_client'
-require 'json'
+require 'yajl'
 
 module DataSift
 	# ApiCLient class.
@@ -46,8 +46,7 @@ module DataSift
 				retval['response_code'] = 200
 
 				# Parse the JSON response
-				retval['data'] = JSON.parse(res)
-
+				retval['data'] = Yajl::Parser.parse(res)
 				# Rate limit headers
 				if (res.headers[:x_ratelimit_limit])
 					retval['rate_limit'] = res.headers[:x_ratelimit_limit]
@@ -61,7 +60,7 @@ module DataSift
 				retval['response_code'] = err.http_code
 
 				# And set the data
-				retval['data'] = JSON.parse(err.response)
+				retval['data'] = Yajl::Parser.parse(err.response)
 			end
 
 			retval


### PR DESCRIPTION
- using POST instead of GET requests while querying the REST API
  (see lib/DataSift/APIClient.rb changes)
- Get rid of regular JSON lib dependency, using Yajl instead (see the 3 modified files)
