### PR TITLE
Add Gemfile to support bundler for use in development.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :rubygems
+gemspec


### PR DESCRIPTION
Using bundler makes development life much easier.Helps prevent
conflicts in dependencies with other local gems
