### PR TITLE
[examples] The historic examples do not work properly

### DIFF
--- a/lib/DataSift/user.rb
+++ b/lib/DataSift/user.rb
@@ -32,8 +32,8 @@ module DataSift
     #* +username+ - The User's DataSift username
     #* +api_key+ - The User's DataSift API key
     def initialize(username, api_key, use_ssl = true)
-      username.strip!
-      api_key.strip!
+      username = username.strip
+      api_key = api_key.strip
 
       raise EInvalidData, 'Please supply valid credentials when creating a User object.' unless username.size > 0 and api_key.size > 0
 


### PR DESCRIPTION
Running a historical example from the root of the tree:

`ruby -I. examples/historics/list.rb $MY_DS_USERNAME $MY_DS_API_KEY`

Yields the following error:

```
$MY_DIR/gem_datasift/lib/DataSift/user.rb:35:in `strip!': can't modify frozen String (RuntimeError)
    from $MY_DIR/gem_datasift/lib/DataSift/user.rb:35:in `initialize'
    from $MY_DIR/gem_datasift/examples/historics/env.rb:20:in `new'
    from $MY_DIR/gem_datasift/examples/historics/env.rb:20:in `initialize'
    from examples/historics/list.rb:14:in `new'
    from examples/historics/list.rb:14:in `<main>'
```

This is because, in Ruby, command-line arguments are frozen (immutable).

This could probably be fixed in env.rb as well, but this fix is sufficient for my needs.
