### PR TITLE
Moved SSL TLSv1 definition from example, into config initializer

### DIFF
--- a/examples/auth.rb
+++ b/examples/auth.rb
@@ -2,10 +2,6 @@ class DataSiftExample
   require 'datasift'
 
   def initialize
-    #only SSLv3 and TLSv1 currently supported, TLSv1 preferred
-    # this is fixed in REST client and is scheduled for the 1.7.0 release
-    # see https://github.com/rest-client/rest-client/pull/123
-    OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'TLSv1'
     @username = 'DATASIFT_USERNAME'
     @api_key  = 'DATASIFT_API_KEY'
     @config   = {:username => @username, :api_key => @api_key, :enable_ssl => true}

--- a/lib/datasift.rb
+++ b/lib/datasift.rb
@@ -41,8 +41,13 @@ module DataSift
   class Client < ApiResource
 
     #+config+:: A hash containing configuration options for the client for e.g.
-    # {username => 'some_user', api_key => 'ds_api_key', open_timeout => 30, timeout => 30}
+    # {username => 'some_user', api_key => 'ds_api_key', 'enable_ssl' => true, open_timeout => 30, timeout => 30}
     def initialize (config)
+      #only SSLv3 and TLSv1 currently supported, TLSv1 preferred
+      # this is fixed in REST client and is scheduled for the 1.7.0 release
+      # see https://github.com/rest-client/rest-client/pull/123
+      OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'TLSv1'
+
       if config == nil
         raise InvalidConfigError.new ('Config cannot be nil')
       end


### PR DESCRIPTION
Ensure we use TLSv1 on all SSL enabled requests. Moves where this is specified from example, to config definition so it is applied to every request
