### PR TITLE
Adding ability to pass in optional parameters into the create a managed source interface.

### DIFF
--- a/lib/managed_source.rb
+++ b/lib/managed_source.rb
@@ -4,12 +4,13 @@ module DataSift
     ##
     # Creates a new managed source
     #+source_type+:: can be facebook_page, googleplus, instagram or yammer
-    def create(source_type, name, parameters = {}, resources = [], auth = [])
+    def create(source_type, name, parameters = {}, resources = [], auth = [], options = {})
       raise BadParametersError.new('source_type and name are required') if source_type.nil? || name.nil?
       params = {
           :source_type => source_type,
           :name        => name
       }
+      params.merge!(options) unless options.empty?
       params.merge!({:auth => auth.is_a?(String) ? auth : MultiJson.dump(auth)}) unless auth.empty?
       params.merge!({:parameters => parameters.is_a?(String) ? parameters : MultiJson.dump(parameters)}) unless parameters.empty?
       params.merge!({:resources => resources.is_a?(String) ? resources : MultiJson.dump(resources)}) if resources.length > 0


### PR DESCRIPTION
For example currently validation needs to be turned off for instagram in order to create a managed source for that type.

This allows a user to pass in optional, undocumented parameters into the create method.