### PR TITLE
Edit api calls

### DIFF
--- a/examples/pylon/pylon_api_v1.3_eg.rb
+++ b/examples/pylon/pylon_api_v1.3_eg.rb
@@ -2,7 +2,9 @@
 # This script runs through all PYLON API endpoints using v1.3 of the API
 ##
 
-require './../auth'
+require_relative './../auth'
+require 'json'
+
 class AnalysisApi < DataSiftExample
   def initialize
     super
@@ -57,7 +59,7 @@ class AnalysisApi < DataSiftExample
       sleep(10)
 
       puts "\nGet details of our running recording by ID"
-      puts @datasift.pylon.get('', recording[:data][:id])[:data].to_json
+      puts @datasift.pylon.get(recording[:data][:id])[:data].to_json
 
       puts "\nYou can also list running recordings"
       puts @datasift.pylon.list[:data].to_json
@@ -71,12 +73,11 @@ class AnalysisApi < DataSiftExample
         }
       }
       puts @datasift.pylon.analyze(
-        '',
+        recording[:data][:id],
         params,
         '',
         nil,
-        nil,
-        recording[:data][:id]
+        nil
       )[:data].to_json
 
       puts "\nFrequency distribution analysis on fb.author.age with filter"
@@ -89,12 +90,11 @@ class AnalysisApi < DataSiftExample
       }
       filter = 'fb.parent.content any "facebook"'
       puts @datasift.pylon.analyze(
-        '',
+        recording[:data][:id],
         params,
         filter,
         nil,
-        nil,
-        recording[:data][:id]
+        nil
       )[:data].to_json
 
       puts "\nTime series analysis"
@@ -109,12 +109,11 @@ class AnalysisApi < DataSiftExample
       start_time = Time.now.to_i - (60 * 60 * 24 * 7) # 7 days ago
       end_time = Time.now.to_i
       puts @datasift.pylon.analyze(
-        '',
+        recording[:data][:id],
         params,
         filter,
         start_time,
-        end_time,
-        recording[:data][:id]
+        end_time
       )[:data].to_json
 
       puts "\nFrequency Distribution with nested queries. Find the top three " \
@@ -144,12 +143,11 @@ class AnalysisApi < DataSiftExample
       start_time = Time.now.to_i - (60 * 60 * 24 * 7)
       end_time = Time.now.to_i
       puts @datasift.pylon.analyze(
-        '',
+        recording[:data][:id],
         params,
         filter,
         start_time,
-        end_time,
-        recording[:data][:id]
+        end_time
       )[:data].to_json
 
       puts "\nTags analysis"
@@ -157,12 +155,11 @@ class AnalysisApi < DataSiftExample
 
       puts "\nGet Public Posts"
       puts @datasift.pylon.sample(
-        '',
+        recording[:data][:id],
         10,
         Time.now.to_i - (60 * 60), # from 1hr ago
         Time.now.to_i, # to 'now'
-        'fb.content contains_any "your, filter, terms"',
-        recording[:data][:id]
+        'fb.content contains_any "your, filter, terms"'
       )[:data].to_json
 
       puts "\nv1.3+ of the API allows you to update the name or hash of recordings;"
@@ -187,7 +184,7 @@ class AnalysisApi < DataSiftExample
       # Cleanup.
       # Stop the recording again to clean up
       sleep(3)
-      @datasift.pylon.stop('', recording[:data][:id])[:data].to_json
+      @datasift.pylon.stop(recording[:data][:id])[:data].to_json
       # Disable the identity created for this example
       @datasift = DataSift::Client.new(@config)
       @datasift.account_identity.update(identity_id, '', 'disabled')

--- a/lib/pylon.rb
+++ b/lib/pylon.rb
@@ -32,10 +32,9 @@ module DataSift
     # @param hash [String] Hash you with the get the status for
     # @param id [String] The ID of the PYLON recording to get
     # @return [Object] API reponse object
-    def get(hash = '', id = '')
-      fail BadParametersError, 'hash or id is required' if hash.empty? && id.empty?
+    def get(id='')
+      fail BadParametersError, 'hash or id is required' if id.empty?
       params = {}
-      params.merge!(hash: hash) unless hash.empty?
       params.merge!(id: id) unless id.empty?
 
       DataSift.request(:GET, 'pylon/get', @config, params)
@@ -109,10 +108,9 @@ module DataSift
     # @param hash [String] CSDL you wish to stop recording
     # @param id [String] ID of the recording you wish to stop
     # @return [Object] API reponse object
-    def stop(hash = '', id = '')
-      fail BadParametersError, 'hash or id is required' if hash.empty? && id.empty?
+    def stop(id = '')
+      fail BadParametersError, 'hash or id is required' if id.empty?
       params = {}
-      params.merge!(hash: hash) unless hash.empty?
       params.merge!(id: id) unless id.empty?
 
       DataSift.request(:PUT, 'pylon/stop', @config, params)
@@ -131,11 +129,10 @@ module DataSift
     # @param end_time [Integer] Optional end timestamp for filtering by date
     # @param id [String] ID of the recording you wish to analyze
     # @return [Object] API reponse object
-    def analyze(hash = '', parameters = '', filter = '', start_time = nil, end_time = nil, id = '')
-      fail BadParametersError, 'hash or id is required' if hash.empty? && id.empty?
+    def analyze(id = '', parameters = '', filter = '', start_time = nil, end_time = nil)
+      fail BadParametersError, 'hash or id is required' if id.empty?
       fail BadParametersError, 'parameters is required' if parameters.empty?
       params = { parameters: parameters }
-      params.merge!(hash: hash) unless hash.empty?
       params.merge!(id: id) unless id.empty?
       params.merge!(filter: filter) unless filter.empty?
       params.merge!(start: start_time) unless start_time.nil?
@@ -150,10 +147,9 @@ module DataSift
     # @param hash [String] Hash of the recording you wish to query
     # @param id [String] ID of the recording you wish to query
     # @return [Object] API reponse object
-    def tags(hash = '', id = '')
-      fail BadParametersError, 'hash or id is required' if hash.empty? && id.empty?
+    def tags(id = '')
+      fail BadParametersError, 'hash or id is required' if id.empty?
       params = {}
-      params.merge!(hash: hash) unless hash.empty?
       params.merge!(id: id) unless id.empty?
 
       DataSift.request(:GET, 'pylon/tags', @config, params)
@@ -168,10 +164,9 @@ module DataSift
     # @param filter [String] Optional PYLON CSDL for a query filter
     # @param id [String] ID of the recording you wish to sample
     # @return [Object] API reponse object
-    def sample(hash = '', count = nil, start_time = nil, end_time = nil, filter = '', id = '')
-      fail BadParametersError, 'hash or id is required' if hash.empty? && id.empty?
+    def sample(id = '', count = nil, start_time = nil, end_time = nil, filter = '')
+      fail BadParametersError, 'hash or id is required' if id.empty?
       params = {}
-      params.merge!(hash: hash) unless hash.empty?
       params.merge!(id: id) unless id.empty?
       params.merge!(count: count) unless count.nil?
       params.merge!(start: start_time) unless start_time.nil?


### PR DESCRIPTION
I can't find a reason to continue to have hash as a parameter being passed into these different API calls. All the documentation now states that besides start&update the 'hash' parameter is never needed.

Additionally, passing in 
hash='' 

as the first parameter in the get call makes it so that everyone using the previous version of the gem has to refactor every single call to add (hash='', id='myid')